### PR TITLE
Section Page Template

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * Template Name: Archives
- */
 get_header();
 ?>
 

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -394,6 +394,11 @@
                     "param": "post_type",
                     "operator": "==",
                     "value": "page"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "!=",
+                    "value": "template-section.php"
                 }
             ],
             [

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -13,17 +13,15 @@
  * @return string The determined header type
  */
 function today_get_header_type( $header_type, $obj ) {
-	$post_type     = $obj->post_type;
-	$post_template = get_page_template_slug( $obj->ID );
+	if ( $obj instanceof WP_Post ) {
+		$post_type     = $obj->post_type;
+		$post_template = get_page_template_slug( $obj->ID );
 
-	if ( $obj instanceof WP_Post && $post_type === 'post' ) {
-		$header_type = 'post';
-	} elseif (
-		$obj instanceof WP_Post &&
-		$post_type === 'page' &&
-		$post_template === 'template-section.php'
-	) {
-		$header_type = 'section';
+		if ( $post_type === 'post' ) {
+			$header_type = 'post';
+		} elseif ( $post_type === 'page' && $post_template === 'template-section.php' ) {
+			$header_type = 'section';
+		}
 	}
 
 	return $header_type;
@@ -42,17 +40,15 @@ add_filter( 'ucfwp_get_header_type', 'today_get_header_type', 11, 2 );
  * @return string The determined header content type
  */
 function today_get_header_content_type( $content_type, $obj ) {
-	$post_type     = $obj->post_type;
-	$post_template = get_page_template_slug( $obj->ID );
+	if ( $obj instanceof WP_Post ) {
+		$post_type     = $obj->post_type;
+		$post_template = get_page_template_slug( $obj->ID );
 
-	if ( $obj instanceof WP_Post && $post_type === 'post' ) {
-		$content_type = 'post';
-	} elseif (
-		$obj instanceof WP_Post &&
-		$post_type === 'page' &&
-		$post_template === 'template-section.php'
-	) {
-		$content_type = 'section';
+		if ( $post_type === 'post' ) {
+			$content_type = 'post';
+		} elseif ( $post_type === 'page' &&	$post_template === 'template-section.php' ) {
+			$content_type = 'section';
+		}
 	}
 
 	return $content_type;

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -13,8 +13,17 @@
  * @return string The determined header type
  */
 function today_get_header_type( $header_type, $obj ) {
-	if ( $obj instanceof WP_Post && $obj->post_type === 'post' ) {
+	$post_type     = $obj->post_type;
+	$post_template = get_page_template_slug( $obj->ID );
+
+	if ( $obj instanceof WP_Post && $post_type === 'post' ) {
 		$header_type = 'post';
+	} elseif (
+		$obj instanceof WP_Post &&
+		$post_type === 'page' &&
+		$post_template === 'template-section.php'
+	) {
+		$header_type = 'section';
 	}
 
 	return $header_type;
@@ -33,8 +42,17 @@ add_filter( 'ucfwp_get_header_type', 'today_get_header_type', 11, 2 );
  * @return string The determined header content type
  */
 function today_get_header_content_type( $content_type, $obj ) {
-	if ( $obj instanceof WP_Post && $obj->post_type === 'post' ) {
+	$post_type     = $obj->post_type;
+	$post_template = get_page_template_slug( $obj->ID );
+
+	if ( $obj instanceof WP_Post && $post_type === 'post' ) {
 		$content_type = 'post';
+	} elseif (
+		$obj instanceof WP_Post &&
+		$post_type === 'page' &&
+		$post_template === 'template-section.php'
+	) {
+		$content_type = 'section';
 	}
 
 	return $content_type;

--- a/template-parts/header-section.php
+++ b/template-parts/header-section.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Header template for the 'Section' page template
+ */
+?>
+
+<?php echo ucfwp_get_header_content_markup(); ?>

--- a/template-parts/header_content-section.php
+++ b/template-parts/header_content-section.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Header content template for the 'Section' page template
+ */
+?>
+
+<?php
+global $post;
+
+$title = wptexturize( $post->post_title );
+?>
+
+<?php if ( $title ): ?>
+<div class="container mt-4 mt-md-5">
+	<h1 class="mb-3">
+		<?php echo $title; ?>
+	</h1>
+	<hr>
+</div>
+<?php endif; ?>

--- a/template-section.php
+++ b/template-section.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Template Name: Section
+ * Template Post Type: page
+ */
+?>
+<?php get_header(); the_post(); ?>
+
+<article class="<?php echo $post->post_status; ?> post-list-item">
+	<div class="container mt-2 mt-md-3 mb-5 pb-sm-4">
+		<?php the_content(); ?>
+	</div>
+</article>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
**Description**
- Adds the Section template for pages and custom header and header content template parts specifically for the section template.
- Removes the ACF 'Page Header Fields' from displaying on pages with the Section template selected since the section pages should all have a similar heading style for consistency. If in a future sprint these pages get re-designed or need custom fields, we can add them back in or create a new group of custom fields specifically for what this template type requires.
- Removes 'Archives' from being listed as a template type option.

**Motivation and Context**
These are updates that will be included in Sprint 1 of the Today Theme rebuild.

**How Has This Been Tested?**
Reviewable in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly. _(I will add this template to the open Documentation issue)_
