### PR TITLE
Rename the 'section' template to 'category'

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -202,7 +202,7 @@
                 {
                     "param": "post_template",
                     "operator": "!=",
-                    "value": "template-section.php"
+                    "value": "template-category.php"
                 }
             ]
         ],

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -19,8 +19,8 @@ function today_get_header_type( $header_type, $obj ) {
 
 		if ( $post_type === 'post' ) {
 			$header_type = 'post';
-		} elseif ( $post_type === 'page' && $post_template === 'template-section.php' ) {
-			$header_type = 'section';
+		} elseif ( $post_type === 'page' && $post_template === 'template-category.php' ) {
+			$header_type = 'category';
 		}
 	}
 
@@ -50,8 +50,8 @@ function today_get_header_content_type( $content_type, $obj ) {
 
 		if ( $post_type === 'post' ) {
 			$content_type = 'post';
-		} elseif ( $post_type === 'page' &&	$post_template === 'template-section.php' ) {
-			$content_type = 'section';
+		} elseif ( $post_type === 'page' &&	$post_template === 'template-category.php' ) {
+			$content_type = 'category';
 		}
 	}
 

--- a/template-category.php
+++ b/template-category.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: Section
+ * Template Name: Category
  * Template Post Type: page
  */
 ?>

--- a/template-parts/header-category.php
+++ b/template-parts/header-category.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Header template for the 'Section' page template
+ * Header template for the 'Category' page template
  */
 ?>
 

--- a/template-parts/header_content-archive.php
+++ b/template-parts/header_content-archive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Header content template for the 'Section' page template
+ * Header content template for the archive pages
  */
 ?>
 

--- a/template-parts/header_content-category.php
+++ b/template-parts/header_content-category.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Header content template for the 'Section' page template
+ * Header content template for the 'Category' page template
  */
 ?>
 


### PR DESCRIPTION
**Description**
See title.

**Motivation and Context**
We decided to use the name 'category' instead of 'section' in order to more closely align with what is actually being displayed on these templates and pages and so that we do not have naming conflicts or confusions with the UCF Section plugin. 

Also, updated the comment for the `header_content-archive.php` file.

**How Has This Been Tested?**
Changes viewable in dev.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly. _Notes in issue #1 have been updated_
