### PR TITLE
Responsive image srcset maximum widths

### DIFF
--- a/includes/features.php
+++ b/includes/features.php
@@ -34,7 +34,7 @@ function today_get_feature_thumbnail( $post, $thumbnail_size='medium_large' ) {
 			$thumbnail_id = today_get_thumbnail_id( $post );
 
 			if ( $thumbnail_id ) {
-				$thumbnail = wp_get_attachment_image( $thumbnail_id, $thumbnail_size, false, array(
+				$thumbnail = ucfwp_get_attachment_image( $thumbnail_id, $thumbnail_size, false, array(
 					'class' => $thumbnail_class,
 					'alt' => ''
 				) );

--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -56,7 +56,7 @@ function today_get_post_header_media( $post ) {
 				// instead of a thumbnail size, to ensure that this theme's
 				// updated 'medium_large' and 'large' dimensions are respected
 				// on images generated using the Today-Bootstrap theme.
-				$img_html  = wp_get_attachment_image( $img['ID'], $thumb_size_dims, false, array(
+				$img_html  = ucfwp_get_attachment_image( $img['ID'], $thumb_size_dims, false, array(
 					'class' => 'img-fluid post-header-image'
 				) );
 


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Replaces usage of `wp_get_attachment_image()` within the theme with `ucfwp_get_attachment_image()`.

Depends on https://github.com/UCF/UCF-WordPress-Theme/pull/54.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures that thumbnails in features and post header images don't contain `srcset` values that force the browser to load a larger image than we expect.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
