### PR TITLE
Category Page Sidebar Enhancements

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1,5 +1,221 @@
 [
     {
+        "key": "group_5c9a8de9376a6",
+        "title": "Category Sidebar Fields",
+        "fields": [
+            {
+                "key": "field_5c9cdf1d61885",
+                "label": "Enable Sidebar",
+                "name": "category_enable_sidebar",
+                "type": "true_false",
+                "instructions": "Enable the sidebar with specific content for Category pages.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "30",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 1,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5c9cdf7861887",
+                "label": "Sidebar Content",
+                "name": "sidebar_content",
+                "type": "flexible_content",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5c9cdf1d61885",
+                            "operator": "==",
+                            "value": "1"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "70",
+                    "class": "",
+                    "id": ""
+                },
+                "layouts": {
+                    "5c9ce0103b79e": {
+                        "key": "5c9ce0103b79e",
+                        "name": "category_sidebar_events",
+                        "label": "Events",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5c9cfecf0c56a",
+                                "label": "",
+                                "name": "",
+                                "type": "message",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Displays the events section in the sidebar.",
+                                "new_lines": "wpautop",
+                                "esc_html": 0
+                            }
+                        ],
+                        "min": "",
+                        "max": "1"
+                    },
+                    "layout_5c9ce14d63fdc": {
+                        "key": "layout_5c9ce14d63fdc",
+                        "name": "category_sidebar_in_the_news",
+                        "label": "In The News",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5c9cffe17e3a5",
+                                "label": "",
+                                "name": "",
+                                "type": "message",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Displays the In The News section in the sidebar.",
+                                "new_lines": "wpautop",
+                                "esc_html": 0
+                            }
+                        ],
+                        "min": "",
+                        "max": "1"
+                    },
+                    "layout_5c9ce13363fdb": {
+                        "key": "layout_5c9ce13363fdb",
+                        "name": "category_sidebar_resources_menu",
+                        "label": "Resources Menu",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5c9cffac7e3a4",
+                                "label": "",
+                                "name": "",
+                                "type": "message",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Displays the Resources menu in the sidebar.",
+                                "new_lines": "wpautop",
+                                "esc_html": 0
+                            }
+                        ],
+                        "min": "",
+                        "max": "1"
+                    },
+                    "layout_5c9ce1de68521": {
+                        "key": "layout_5c9ce1de68521",
+                        "name": "category_sidebar_spotlight",
+                        "label": "Spotlight",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5c9ce23ed7f46",
+                                "label": "Select Spotlight",
+                                "name": "spotlight_object",
+                                "type": "post_object",
+                                "instructions": "Select a spotlight to display in the sidebar.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "ucf_spotlight"
+                                ],
+                                "taxonomy": "",
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "object",
+                                "ui": 1
+                            }
+                        ],
+                        "min": "",
+                        "max": "1"
+                    },
+                    "layout_5c9ce16b63fdd": {
+                        "key": "layout_5c9ce16b63fdd",
+                        "name": "category_sidebar_custom_content",
+                        "label": "Custom Content",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5c9ce0516188e",
+                                "label": "Custom Content",
+                                "name": "custom_content",
+                                "type": "wysiwyg",
+                                "instructions": "Insert custom content to display in the sidebar.",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 1,
+                                "delay": 0
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    }
+                },
+                "button_label": "Add Row",
+                "min": "",
+                "max": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "page"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "template-category.php"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
         "key": "group_58f7a73f5fecc",
         "title": "Page Header Fields",
         "fields": [

--- a/functions.php
+++ b/functions.php
@@ -12,6 +12,7 @@ include_once 'includes/post-functions.php';
 include_once 'includes/archive-functions.php';
 include_once 'includes/weather-functions.php';
 include_once 'includes/tag-cloud-functions.php';
+include_once 'includes/category-functions.php';
 
 
 // Plugin extras/overrides

--- a/includes/category-functions.php
+++ b/includes/category-functions.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Provides functions specifically for pages assigned to the Category template
+ */
+
+
+/**
+ * Returns the sidebar events section markup.
+ *
+ * @since 1.0.0
+ * @author Cadie Brown
+ * @return string HTML markup for the sidebar events section.
+ **/
+function today_get_category_sidebar_events() {
+	ob_start();
+	?>
+		<div class="mb-5">
+			<h2 class="h6 text-uppercase text-default-aw mb-3">Events at UCF</h2>
+			<?php echo do_shortcode( '[ucf-events feed_url="https://events.ucf.edu/upcoming/feed.json" layout="classic" limit="4" title=""]' ); ?>
+			<p class="text-right"><a href="https://events.ucf.edu/upcoming/">View All Events</a></p>
+		</div>
+	<?php
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns the sidebar news section markup.
+ *
+ * @since 1.0.0
+ * @author Cadie Brown
+ * @return string HTML markup for the sidebar news section.
+ **/
+function today_get_category_sidebar_news() {
+	ob_start();
+	?>
+	<div class="mb-5">
+		<h2 class="h6 text-uppercase text-default-aw mb-3">UCF In the News</h2>
+		<?php echo do_shortcode( '[ucf-post-list layout="condensed" post_type="ucf_resource_link" numberposts="4"]' ); ?>
+		<p class="text-right"><a href="https://wwwdev.smca.ucf.edu/today/in-the-news/">View All UCF In The News</a></p>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns the sidebar resources menu markup.
+ *
+ * @since 1.0.0
+ * @author Cadie Brown
+ * @return string HTML markup for the sidebar resources menu.
+ **/
+function today_get_category_sidebar_resources_menu() {
+	ob_start();
+	?>
+	<div class="mb-5">
+		<h2 class="h6 text-uppercase text-default-aw mb-3">Resources</h2>
+		<?php
+			wp_nav_menu( array(
+				'menu'       => 'Resources',
+				'menu_class' => 'list-unstyled'
+			) );
+		?>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns the sidebar spotlight markup.
+ *
+ * @since 1.0.0
+ * @author Cadie Brown
+ * @param string $spotlight_slug The slug for the selected spotlight.
+ * @return string HTML markup for the sidebar spotlight.
+ **/
+function today_get_category_sidebar_spotlight( $spotlight_slug ) {
+	ob_start();
+	?>
+	<div class="mb-5">
+		<?php echo do_shortcode( '[ucf-spotlight slug="' . $spotlight_slug . '"]' ); ?>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns the sidebar custom content markup.
+ *
+ * @since 1.0.0
+ * @author Cadie Brown
+ * @param string $custom_content The custom content markup
+ * @return string HTML markup for the sidebar custom content section.
+ **/
+function today_get_category_sidebar_custom_content( $custom_content ) {
+	ob_start();
+	?>
+	<div class="mb-5">
+		<?php echo $custom_content; ?>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns the sidebar markup for category pages.
+ *
+ * @since 1.0.0
+ * @author Cadie Brown
+ * @param integer $post_id WP Post ID
+ * @return string HTML markup for the category sidebar
+ **/
+function today_get_category_sidebar_markup( $post_id ) {
+	$markup = '';
+
+	if ( have_rows( 'sidebar_content', $post_id ) ) :
+		while ( have_rows( 'sidebar_content', $post_id ) ) : the_row();
+			switch ( get_row_layout() ) {
+				case 'category_sidebar_events' :
+					$markup .= today_get_category_sidebar_events();
+					break;
+				case 'category_sidebar_in_the_news' :
+					$markup .= today_get_category_sidebar_news();
+					break;
+				case 'category_sidebar_resources_menu' :
+					$markup .= today_get_category_sidebar_resources_menu();
+					break;
+				case 'category_sidebar_spotlight' :
+					if ( $spotlight = get_sub_field( 'spotlight_object' ) ) {
+						$markup .= today_get_category_sidebar_spotlight( $spotlight->post_name );
+					}
+					break;
+				case 'category_sidebar_custom_content' :
+					if ( $custom_content = get_sub_field( 'custom_content' ) ) {
+						$markup .= today_get_category_sidebar_custom_content( $custom_content );
+					}
+					break;
+				default :
+					break;
+			}
+		endwhile;
+	else :
+		return 'nothing';
+	endif;
+
+	return $markup;
+}

--- a/includes/category-functions.php
+++ b/includes/category-functions.php
@@ -37,7 +37,7 @@ function today_get_category_sidebar_news() {
 	<div class="mb-5">
 		<h2 class="h6 text-uppercase text-default-aw mb-3">UCF In the News</h2>
 		<?php echo do_shortcode( '[ucf-post-list layout="condensed" post_type="ucf_resource_link" numberposts="4"]' ); ?>
-		<p class="text-right"><a href="https://wwwdev.smca.ucf.edu/today/in-the-news/">View All UCF In The News</a></p>
+		<p class="text-right"><a href="<?php echo get_permalink( get_page_by_title( 'UCF in the News' ) ); ?>">View All UCF In The News</a></p>
 	</div>
 	<?php
 	return ob_get_clean();

--- a/includes/category-functions.php
+++ b/includes/category-functions.php
@@ -117,7 +117,7 @@ function today_get_category_sidebar_custom_content( $custom_content ) {
 function today_get_category_sidebar_markup( $post_id ) {
 	$markup = '';
 
-	if ( have_rows( 'sidebar_content', $post_id ) ) :
+	if ( have_rows( 'sidebar_content', $post_id ) ) {
 		while ( have_rows( 'sidebar_content', $post_id ) ) : the_row();
 			switch ( get_row_layout() ) {
 				case 'category_sidebar_events' :
@@ -143,9 +143,7 @@ function today_get_category_sidebar_markup( $post_id ) {
 					break;
 			}
 		endwhile;
-	else :
-		return;
-	endif;
+	}
 
 	return $markup;
 }

--- a/includes/category-functions.php
+++ b/includes/category-functions.php
@@ -144,7 +144,7 @@ function today_get_category_sidebar_markup( $post_id ) {
 			}
 		endwhile;
 	else :
-		return 'nothing';
+		return;
 	endif;
 
 	return $markup;

--- a/template-category.php
+++ b/template-category.php
@@ -8,8 +8,18 @@
 
 <article class="<?php echo $post->post_status; ?> post-list-item">
 	<div class="container mt-2 mt-md-3 mb-5 pb-sm-4">
+	<?php if ( get_field( 'category_enable_sidebar' ) ) : ?>
+		<div class="row">
+			<div class="col-lg-8">
+				<?php the_content(); ?>
+			</div>
+			<div class="col-lg-4 pl-lg-5">
+				<?php echo today_get_category_sidebar_markup( $post->ID ); ?>
+			</div>
+		</div>
+	<?php else : ?>
 		<?php the_content(); ?>
-	</div>
+	<?php endif; ?>
 </article>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
**Description**
Adds ACF fields to the Category template pages which enable the use of a sidebar. The sidebar contents can be added, removed, and re-arranged per page. The sidebar 'sections' included are: events, in the news, resources menu,  a spotlight (which uses posts from the UCF Spotlights plugin), and custom content. The UCF Spotlights plugin has been installed in order to utilize those instead of creating something custom for category pages.

**NOTE:** I've started working on making some of the options customizable in the ACF fields, example: the Events shortcode feed URL, layout, limit, etc. Those updates will be included in a separate PR.

**Motivation and Context**
Trying to improve the use of the same content in the sidebar across all Category pages, while keeping each page independently customizable. The Today team also mentioned creating Spotlights for category pages in the last meeting. 

**How Has This Been Tested?**
Viewable in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
