### PR TITLE
Thumbnail URL utility function

### DIFF
--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -58,7 +58,7 @@ function today_get_thumbnail_id( $post, $use_fallback=true ) {
  * @param bool $use_fallback Whether or not a fallback image should be returned if a thumbnail isn't set
  * @return mixed Attachment ID (int) or null on failure
  */
-function today_get_thumbnail_url( $post, $thumbnail_size='thumbnail', $use_fallback=true ) {
+function today_get_thumbnail_url( $post, $thumbnail_size='medium', $use_fallback=true ) {
 	if ( is_numeric( $post ) ) {
 		$post = get_post( $post );
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds the utility function `today_get_thumbnail_url()`, which returns a post's thumbnail URL by size, and optionally a fallback if no image is available.

This new function and `today_get_thumbnail_id()` now also accept a post ID in the `$post` arg (instead of just a `WP_Post` object) to help support the Today Utilities plugin, which needs to be able to pass in a post ID.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A separate function that returns an image URL, and not just an attachment ID, is necessary for the Today Utilities plugin to be able to utilize header video poster images as story thumbnails.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
