### PR TITLE
Originally posted

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -531,10 +531,10 @@
             },
             {
                 "key": "field_5c813a34c81af",
-                "label": "Updated Date",
-                "name": "post_header_updated_date",
-                "type": "date_picker",
-                "instructions": "The updated date displays under the publish date when set. Leave blank to exclude story updated date.",
+                "label": "Published Date",
+                "name": "post_header_publish_date",
+                "type": "read_only",
+                "instructions": "The date the post was originally published.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -542,9 +542,8 @@
                     "class": "",
                     "id": ""
                 },
-                "display_format": "F j, Y",
-                "return_format": "F j, Y",
-                "first_day": 1
+                "copy_to_clipboard": 0,
+                "display_type": "text"
             },
             {
                 "key": "field_5c813eaac81b1",

--- a/includes/config.php
+++ b/includes/config.php
@@ -313,7 +313,7 @@ add_filter( 'acf/fields/wysiwyg/toolbars', 'today_acf_inline_text_toolbar' );
 /**
  *
  */
-function today_pre_get_posts( $query ) {
+function today_pre_get_posts( &$query ) {
 	$q_post_type     = isset( $query->query_vars['post_type'] ) ? $query->query_vars['post_type'] : null;
 	$q_orderby       = isset( $query->query_vars['orderby'] ) ? $query->query_vars['orderby'] : null;
 	$q_orderby_array = $q_orderby ? explode( ' ', $q_orderby ) : array();
@@ -352,14 +352,38 @@ function today_pre_get_posts( $query ) {
 		)
 	) {
 		$q_orderby_array_datepos = array_search( 'date', $q_orderby_array );
-		array_splice( $q_orderby_array, $q_orderby_array_datepos, 0, 'meta_value_num' );
+		array_splice( $q_orderby_array, $q_orderby_array_datepos, 0, 'meta_value_datetime' );
 		$q_orderby = implode( ' ', $q_orderby_array );
 		$query->set( 'meta_key', 'post_header_updated_date' );
-		$query->set( 'orderby', $q_orderby );
+		$query->set( 'meta_type', 'DATETIME' );
+		$query->set( 'orderby', $q_orderby);
 	}
-
-	// return
-	return $query;
 }
 
 add_filter( 'pre_get_posts', 'today_pre_get_posts' );
+
+function today_post_orderby( $orderby ) {
+	global $wp_query, $wpdb;
+
+	// Short curcuit if even one of these query_vars is not set
+	if ( ! isset( $wp_query->query_vars['post_type'] )
+		|| ! isset( $wp_query->query_vars['meta_key'] )
+		|| ! isset( $wp_query->query_vars['meta_type'] )
+		|| ! isset( $wp_query->query_vars['orderby'] ) ) {
+			return $orderby;
+		}
+
+	// Only modify the query if all the query_vars match up
+	// with what we set as the default.
+	if ( $wp_query->query_vars['post_type'] === 'post'
+		&& $wp_query->query_vars['meta_key'] === 'post_header_updated_date'
+		&& $wp_query->query_vars['meta_type'] === 'DATETIME'
+		&& in_array( 'meta_value_datetime', explode( ' ', $wp_query->query_vars['orderby'] ) ) ) {
+
+		$orderby = " COALESCE(CAST($wpdb->postmeta.meta_value as DATETIME), $wpdb->posts.post_date) DESC";
+	}
+
+	return $orderby;
+}
+
+add_filter( 'posts_orderby', 'today_post_orderby', 10, 1 );

--- a/includes/config.php
+++ b/includes/config.php
@@ -311,14 +311,15 @@ add_filter( 'acf/fields/wysiwyg/toolbars', 'today_acf_inline_text_toolbar' );
 
 function today_post_insert_override( $post_id, $post, $update ) {
 	if ( $post->post_type !== 'post'
-		|| wp_is_post_revision( $post_id ) ) {
+		|| wp_is_post_revision( $post_id )
+		|| $post->post_status !== 'publish' ) {
 		return;
 	}
 
 	// Get post meta
-	$publish_date = get_post_meta( $post_id, 'page_header_publish_date', true );
+	$publish_date = get_post_meta( $post_id, 'post_header_publish_date', true );
 	if ( ! $publish_date ) {
-		update_post_meta( $post_id, 'page_header_publish_date', date( 'Y-m-d' ) );
+		update_post_meta( $post_id, 'post_header_publish_date', date( 'Y-m-d' ) );
 	}
 }
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -360,7 +360,7 @@ function today_pre_get_posts( &$query ) {
 	}
 }
 
-add_filter( 'pre_get_posts', 'today_pre_get_posts' );
+// add_filter( 'pre_get_posts', 'today_pre_get_posts' );
 
 function today_post_orderby( $orderby ) {
 	global $wp_query, $wpdb;
@@ -386,4 +386,4 @@ function today_post_orderby( $orderby ) {
 	return $orderby;
 }
 
-add_filter( 'posts_orderby', 'today_post_orderby', 10, 1 );
+// add_filter( 'posts_orderby', 'today_post_orderby', 10, 1 );

--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -137,9 +137,11 @@ function today_get_post_header_media( $post ) {
  * @return string HTML markup for the metadata content
  */
 function today_get_post_meta_info( $post ) {
-	$date_format  = 'F j, Y';
-	$byline       = get_field( 'post_author_byline', $post ) ?: wptexturize( get_the_author() );
-	$updated_date = get_field( 'post_header_updated_date', $post );
+	$date_format   = 'F j, Y';
+	$byline        = get_field( 'post_author_byline', $post ) ?: wptexturize( get_the_author() );
+	$updated_date  = date( $date_format, strtotime( $post->post_date ) );
+	$orig_date_val = get_field( 'post_header_publish_date', $post );
+	$original_date = isset( $orig_date_val ) ? date( $date_format, strtotime( $orig_date_val ) ) : $updated_date;
 
 	ob_start();
 ?>
@@ -147,10 +149,10 @@ function today_get_post_meta_info( $post ) {
 		<p class="mb-0">
 			<span>By <?php echo $byline; ?></span>
 			<span class="hidden-xs-down px-1" aria-hidden="true">|</span>
-			<span class="d-block d-sm-inline"><?php echo date( $date_format, strtotime( $post->post_date ) ); ?></span>
+			<span class="d-block d-sm-inline"><?php echo $original_date; ?></span>
 		</p>
 
-		<?php if ( $updated_date ) : ?>
+		<?php if ( $updated_date !== $original_date ) : ?>
 		<p class="mt-1 mb-0">
 			<strong>Updated</strong> <?php echo date( $date_format, strtotime( $updated_date ) ); ?>
 		</p>


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a read-only "Published Date" field to the Post Custom Fields. This will be used to output the original date, vs. a newer "updated date" (which will be controlled by the `post_date` field).

**Motivation and Context**
Editors need the ability to update stories and indicate that they've been updated. They also need the stories list to be ordered by the "updated" dates. It was inefficient to use a postmeta field for the updated date as this required an expensive join in order to do a proper orderby clause, so the built in `post_date` will now represent the updated date and the `post_header_publish_date` will represent the original publish date.

**How Has This Been Tested?**
Changes can be seen in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
