### PR TITLE
Category template, h1s

### DIFF
--- a/category.php
+++ b/category.php
@@ -1,0 +1,45 @@
+<?php get_header(); ?>
+
+<?php
+$posts = get_posts( array(
+	'numberposts' => 10,
+	'cat'         => get_queried_object()->term_id
+) );
+
+if ( isset( $posts ) ) {
+	$first_post = array_shift( $posts );
+}
+?>
+
+<div class="container mt-2 mt-md-3 mb-5 pb-sm-4">
+	<div class="row">
+		<div class="col-lg-8">
+			<?php if ( $first_post ): ?>
+				<div class="pb-4">
+					<?php echo today_display_feature_vertical( $first_post, array( 'layout__type' => 'primary' ) ); ?>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( $posts ): ?>
+				<div class="row">
+					<?php foreach ( $posts as $post ): ?>
+						<div class="col-lg-4 mb-4">
+							<?php echo today_display_feature_vertical( $post ); ?>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( ! $first_post && ! $posts ): ?>
+				<p>No results found.</p>
+			<?php endif; ?>
+		</div>
+		<div class="col-lg-4 pl-lg-5">
+			<?php echo today_display_sidebar_events(); ?>
+			<?php echo today_display_sidebar_external_stories(); ?>
+			<?php echo today_display_sidebar_menu(); ?>
+		</div>
+	</div>
+</div>
+
+<?php get_footer(); ?>

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -4,6 +4,28 @@
  **/
 
 /**
+ * Modifies the h1 text for the given object.
+ *
+ * Adds "News" to the end of category and tag titles.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @param string $title The object's determined title
+ * @param mixed $obj A queried object (e.g. WP_Post, WP_Term), or null
+ * @return string The modified title
+ */
+function today_get_header_title_after( $title, $obj ) {
+	if ( is_category() || is_tag() ) {
+		$title .= ' News';
+	}
+
+	return $title;
+}
+
+add_filter( 'ucfwp_get_header_title_after', 'today_get_header_title_after', 10, 2 );
+
+
+/**
  * Modifies header markup for the given object.
  *
  * Returns an empty string on the homepage, which


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Adds a template for non-top-level categories.  It's effectively identical to `tag.php`.
- Adds " News" to the end of category and tag archive h1 text to match top-level category pages.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support non-top-level category archives.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
