### PR TITLE
Remove unused image sizes

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -14,6 +14,30 @@ define( 'TODAY_SHORT_EXCERPT_LENGTH', 25 );
 
 
 /**
+ * Initialization functions to be fired early when WordPress loads the theme.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ */
+function today_init() {
+	// Remove page header image sizes, since the UCF WP Theme's
+	// media header logic isn't utilized in this theme.
+	remove_image_size( 'header-img' );
+	remove_image_size( 'header-img-sm' );
+	remove_image_size( 'header-img-md' );
+	remove_image_size( 'header-img-lg' );
+	remove_image_size( 'header-img-xl' );
+	remove_image_size( 'bg-img' );
+	remove_image_size( 'bg-img-sm' );
+	remove_image_size( 'bg-img-md' );
+	remove_image_size( 'bg-img-lg' );
+	remove_image_size( 'bg-img-xl' );
+}
+
+add_action( 'after_setup_theme', 'today_init', 11 );
+
+
+/**
  * Defines sections used in the WordPress Customizer.
  *
  * @author Jo Dickson


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Unregisters the UCF WP Theme's header media image sizes.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since media headers aren't used in this theme, these image sizes aren't necessary.  Removing them prevents generation of a bunch of unused images whenever new media is uploaded to the media library.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
