### PR TITLE
Renamed Syndication Fields metabox; updated permissions so that superadmins have access to it

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -494,6 +494,65 @@
         "description": ""
     },
     {
+        "key": "group_5c9e1c1417520",
+        "title": "Main Site News",
+        "fields": [
+            {
+                "key": "field_5c9e1c1c15df3",
+                "label": "Promote on Main Site",
+                "name": "post_main_site_story",
+                "type": "true_false",
+                "instructions": "When checked, the story will appear in the news feed on UCF.edu.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "post"
+                },
+                {
+                    "param": "current_user_role",
+                    "operator": "==",
+                    "value": "administrator"
+                }
+            ],
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "post"
+                },
+                {
+                    "param": "current_user_role",
+                    "operator": "==",
+                    "value": "super_admin"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "side",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 1,
+        "description": ""
+    },
+    {
         "key": "group_58f7a73f5fecc",
         "title": "Page Header Fields",
         "fields": [
@@ -1435,53 +1494,6 @@
         ],
         "menu_order": 0,
         "position": "normal",
-        "style": "default",
-        "label_placement": "top",
-        "instruction_placement": "label",
-        "hide_on_screen": "",
-        "active": 1,
-        "description": ""
-    },
-    {
-        "key": "group_5c9e1c1417520",
-        "title": "Syndication Fields",
-        "fields": [
-            {
-                "key": "field_5c9e1c1c15df3",
-                "label": "Promote on Main Site",
-                "name": "post_main_site_story",
-                "type": "true_false",
-                "instructions": "When checked, the story will appear in the news feed on UCF.edu.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "",
-                "default_value": 0,
-                "ui": 1,
-                "ui_on_text": "",
-                "ui_off_text": ""
-            }
-        ],
-        "location": [
-            [
-                {
-                    "param": "post_type",
-                    "operator": "==",
-                    "value": "post"
-                },
-                {
-                    "param": "current_user_role",
-                    "operator": "==",
-                    "value": "administrator"
-                }
-            ]
-        ],
-        "menu_order": 0,
-        "position": "side",
         "style": "default",
         "label_placement": "top",
         "instruction_placement": "label",


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Renamed Syndication Fields metabox to "Main Site News"
- Updated permissions on the metabox so that superadmins can view it when editing posts

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Renamed per Laura's request
- Super admins couldn't view the metabox

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
