### PR TITLE
Header image sizes

### DIFF
--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -31,49 +31,20 @@ function today_get_post_header_media( $post ) {
 			break;
 		case 'image':
 		default:
-			$thumb_dims_medium_large = array(
-				intval( get_option( 'medium_large_size_w' ) ),
-				intval( get_option( 'medium_large_size_h' ) )
-			);
-			$thumb_dims_large = array(
-				intval( get_option( 'large_size_w' ) ),
-				intval( get_option( 'large_size_h' ) )
-			);
-
-			$img             = get_field( 'post_header_image', $post );
-			$thumb_size      = get_page_template_slug( $post ) === '' ? 'large' : 'medium_large';
-			$thumb_size_dims = ( $thumb_size === 'large' ) ? $thumb_dims_large : $thumb_dims_medium_large;
-			$img_html        = '';
-			$min_width       = 730;  // Minimum acceptable, non-fluid width of a <figure>.
+			$img         = get_field( 'post_header_image', $post );
+			$thumb_size  = get_page_template_slug( $post ) === '' ? 'large' : 'medium_large';
+			$img_html    = '';
+			$min_width   = 730;  // Minimum acceptable, non-fluid width of a <figure>.
 								     // Loosely based on maximum size of post content column in default and two-col templates.
 								     // Should be a width that comfortably fits one or more lines of an image caption.
-			$max_width       = 1140; // Default max-width value for <figure>
-			$thumb_width     = 0;    // Default calculated width of the thumbnail at $thumb_size.
-			$caption         = '';
+			$max_width   = 1140; // Default max-width value for <figure>
+			$thumb_width = 0;    // Default calculated width of the thumbnail at $thumb_size.
+			$caption     = '';
 
 			if ( $img ) {
-				// NOTE: we pass in an array of dimensions ($thumb_size_dims),
-				// instead of a thumbnail size, to ensure that this theme's
-				// updated 'medium_large' and 'large' dimensions are respected
-				// on images generated using the Today-Bootstrap theme.
-				$img_html  = ucfwp_get_attachment_image( $img['ID'], $thumb_size_dims, false, array(
+				$img_html  = ucfwp_get_attachment_image( $img['ID'], $thumb_size, false, array(
 					'class' => 'img-fluid post-header-image'
 				) );
-
-				// Modify $thumb_size for quick reference below when
-				// determining $thumb_width.
-				if ( $thumb_size === 'large' ) {
-					// If the 'full' width image's width doesn't exceed the new
-					// 'large' maximum width, set $thumb_size to 'full'.
-					// Useful for images uploaded using the old Today-Bootstrap
-					// theme, where the 'large' size was only 1024px wide.
-					if (
-						isset( $img['width'] )
-						&& intval( $img['width'] ) <= $thumb_dims_large[0]
-					) {
-						$thumb_size = 'full';
-					}
-				}
 
 				// Calculate a max-width for the <figure> here so that
 				// an included image caption doesn't exceed the width
@@ -84,19 +55,8 @@ function today_get_post_header_media( $post ) {
 				// background.
 				// For smaller images, display them centered within a
 				// full-width div with a gray bg.
-				switch ( $thumb_size ) {
-					case 'full':
-						// Set $thumb_width to the full-size img width
-						if ( isset( $img['width'] ) ) {
-							$thumb_width = intval( $img['width'] );
-						}
-						break;
-					default:
-						// Set $thumb_width to the specific thumbnail size width
-						if ( isset( $img['sizes'][$thumb_size . '-width'] ) ) {
-							$thumb_width = intval( $img['sizes'][$thumb_size . '-width'] );
-						}
-						break;
+				if ( isset( $img['sizes'][$thumb_size . '-width'] ) ) {
+					$thumb_width = intval( $img['sizes'][$thumb_size . '-width'] );
 				}
 				if ( $thumb_width >= $min_width ) {
 					$max_width = $thumb_width;

--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -35,8 +35,8 @@ function today_get_post_header_media( $post ) {
 			$thumb_size  = get_page_template_slug( $post ) === '' ? 'large' : 'medium_large';
 			$img_html    = '';
 			$min_width   = 730;  // Minimum acceptable, non-fluid width of a <figure>.
-								     // Loosely based on maximum size of post content column in default and two-col templates.
-								     // Should be a width that comfortably fits one or more lines of an image caption.
+								 // Loosely based on maximum size of post content column in default and two-col templates.
+								 // Should be a width that comfortably fits one or more lines of an image caption.
 			$max_width   = 1140; // Default max-width value for <figure>
 			$thumb_width = 0;    // Default calculated width of the thumbnail at $thumb_size.
 			$caption     = '';


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Removes logic when fetching a post's header image that tries to accommodate for Today-Bootstrap image sizes.  This logic now assumes that all image thumbnails have been regenerated, and that fetching a thumbnail by its size name will return the dimensions registered in this theme.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some cases, stories would display extremely large images if the existing 'large' size was smaller than the child theme's registered dimensions--resulting in the next size up, 'full', being returned instead.

This update assumes thumbnails have been regenerated to work around this problem.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev post-thumbnail regeneration.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
