### PR TITLE
Added ability to specify a custom thumbnail image for stories with a header video

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -869,38 +869,6 @@
                 "return_format": "value"
             },
             {
-                "key": "field_5c813f8ac81b8",
-                "label": "Header Image",
-                "name": "post_header_image",
-                "type": "image",
-                "instructions": "Select or upload a header image with dimensions of 1200x800 for this story. The image file size must be less than 800KB.",
-                "required": 0,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_5c813fb7c81b9",
-                            "operator": "==",
-                            "value": "image"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "return_format": "array",
-                "preview_size": "thumbnail",
-                "library": "all",
-                "min_width": "",
-                "min_height": "",
-                "min_size": "",
-                "max_width": 1200,
-                "max_height": 800,
-                "max_size": "0.5",
-                "mime_types": "jpg, jpeg"
-            },
-            {
                 "key": "field_5c814048c81bb",
                 "label": "Header Video",
                 "name": "post_header_video_url",
@@ -923,6 +891,30 @@
                 },
                 "width": "",
                 "height": ""
+            },
+            {
+                "key": "field_5c813f8ac81b8",
+                "label": "Header\/Thumbnail Image",
+                "name": "post_header_image",
+                "type": "image",
+                "instructions": "Select or upload an image with dimensions of 1200x800 for this story. The image file size must be less than 800KB.\r\n<br><br>\r\nWhen the \"Header Media Type\" value is set to \"Image\", this image will be used as the header image on the story, as well as the thumbnail image when this story is displayed in lists of stories.\r\n<br><br>\r\nWhen the \"Header Media Type\" value is set to \"Video\", if an image is provided, the image will be used as the thumbnail when this story is displayed in lists of stories.  If no image is provided, WordPress will attempt to fetch and use a poster image dynamically based on the \"Header Video\" URL provided.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "return_format": "array",
+                "preview_size": "thumbnail",
+                "library": "all",
+                "min_width": "",
+                "min_height": "",
+                "min_size": "",
+                "max_width": 1200,
+                "max_height": 800,
+                "max_size": "",
+                "mime_types": "jpg, jpeg"
             },
             {
                 "key": "field_5c813f04c81b3",

--- a/includes/features.php
+++ b/includes/features.php
@@ -18,29 +18,33 @@ function today_get_feature_thumbnail( $post, $thumbnail_size='medium_large' ) {
 	$thumbnail_class   = 'media-background object-fit-cover feature-thumbnail';
 	$header_media_type = get_field( 'header_media_type', $post );
 
-	switch ( $header_media_type ) {
-		case 'video':
-			// Get video url (prevent ACF oEmbed processing)
-			$video_url           = get_field( 'post_header_video_url', $post, false );
-			$video_thumbnail_w   = intval( get_option( "{$thumbnail_size}_size_w" ) );
-			$video_thumbnail_h   = intval( get_option( "{$thumbnail_size}_size_h" ) );
-			$video_thumbnail_url = today_get_oembed_thumbnail( $video_url, $video_thumbnail_w, $video_thumbnail_h );
+	// Fetch a thumbnail ID for the post.
+	//
+	// Only have `today_get_thumbnail_id()` return a fallback
+	// thumbnail ID if this is NOT a post with a video header.
+	//
+	// We will fetch a video poster to use as a fallback instead
+	// for video header posts, if necessary.
+	$use_fallback = ( $header_media_type === 'video' ) ? false : true;
+	$thumbnail_id = today_get_thumbnail_id( $post, $use_fallback );
 
-			if ( $video_thumbnail_url ) {
-				$thumbnail = '<img class="' . $thumbnail_class . '" src="' . $video_thumbnail_url . '" alt="">';
-			}
-			break;
-		case 'image':
-		default:
-			$thumbnail_id = today_get_thumbnail_id( $post );
+	// Generate thumbnail HTML based on the thumbnail ID
+	if ( $thumbnail_id ) {
+		$thumbnail = ucfwp_get_attachment_image( $thumbnail_id, $thumbnail_size, false, array(
+			'class' => $thumbnail_class,
+			'alt' => ''
+		) );
+	}
+	else if ( $header_media_type === 'video' ) {
+		// Get video url (prevent ACF oEmbed processing)
+		$video_url           = get_field( 'post_header_video_url', $post, false );
+		$video_thumbnail_w   = intval( get_option( "{$thumbnail_size}_size_w" ) );
+		$video_thumbnail_h   = intval( get_option( "{$thumbnail_size}_size_h" ) );
+		$video_thumbnail_url = today_get_oembed_thumbnail( $video_url, $video_thumbnail_w, $video_thumbnail_h );
 
-			if ( $thumbnail_id ) {
-				$thumbnail = ucfwp_get_attachment_image( $thumbnail_id, $thumbnail_size, false, array(
-					'class' => $thumbnail_class,
-					'alt' => ''
-				) );
-			}
-			break;
+		if ( $video_thumbnail_url ) {
+			$thumbnail = '<img class="' . $thumbnail_class . '" src="' . $video_thumbnail_url . '" alt="">';
+		}
 	}
 
 	// Use an absolute fallback if a thumbnail couldn't be retrieved

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -23,7 +23,7 @@ function today_get_thumbnail_id( $post, $use_fallback=true ) {
 	$attachment_id = null;
 
 	// Return the post's header image on posts
-	if ( $post->post_type === 'post' && get_field( 'header_media_type', $post ) === 'image' ) {
+	if ( $post->post_type === 'post' ) {
 		$attachment    = get_field( 'post_header_image', $post );
 		$attachment_id = isset( $attachment['id'] ) ? $attachment['id'] : null;
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  This update also removes the 500KB filesize limit on header images, which maybe confusing with the sitewide limit for images (800KB).

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The content team has expressed interest in being able to add some sort of adjustment to video story thumbnails to indicate that there's a video to play.  Enabling the header image field for video stories will allow users to upload a custom thumbnail, while still displaying the large video when viewing the single story.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
