### PR TITLE
Updates for feed compatibility

### DIFF
--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -98,7 +98,7 @@ function today_get_post_header_media( $post ) {
  */
 function today_get_post_meta_info( $post ) {
 	$date_format   = 'F j, Y';
-	$byline        = get_field( 'post_author_byline', $post ) ?: wptexturize( get_the_author() );
+	$byline        = wptexturize( get_the_author() );
 	$updated_date  = date( $date_format, strtotime( $post->post_date ) );
 	$orig_date_val = get_field( 'post_header_publish_date', $post );
 	$original_date = isset( $orig_date_val ) ? date( $date_format, strtotime( $orig_date_val ) ) : $updated_date;
@@ -139,12 +139,9 @@ function today_get_post_meta_info( $post ) {
  * @return string Author bio markup
  */
 function today_get_post_author_bio( $post ) {
-	$author_title = get_field( 'post_author_title', $post );
-
-	$author_byline = trim( get_field( 'post_author_byline', $post ) );
-	$author_byline = ( $author_byline !== '' ) ? $author_byline : get_the_author();
-
-	$author_bio = trim( get_field( 'post_author_bio', $post ) );
+	$author_byline = get_the_author();
+	$author_title  = get_field( 'post_author_title', $post );
+	$author_bio    = trim( get_field( 'post_author_bio', $post ) );
 
 	ob_start();
 	if ( $author_bio ) :

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -4,6 +4,57 @@
  */
 
 /**
+ * Filters requests for WordPress's built-in `get_post_thumbnail_id()`
+ * to return the Header Image/Thumbnail field for posts.
+ *
+ * Useful for third-party plugins that reference thumbnails.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @param mixed $value A determined thumbnail ID, or null
+ * @param int $object_id Object ID (in this case, a post object ID)
+ * @param string $meta_key The meta key name
+ * @param bool $single Whether to return only the first value of the specified $meta_key
+ * @return mixed The thumbnail ID, or null
+ */
+function today_filter_thumbnail_ids( $value, $object_id, $meta_key, $single ) {
+    if ( $meta_key === '_thumbnail_id' ) {
+		$post = get_post( $object_id );
+		if ( $post instanceof WP_Post && $post->post_type === 'post' ) {
+			$attachment = get_field( 'post_header_image', $post );
+			$value      = isset( $attachment['id'] ) ? $attachment['id'] : null;
+		}
+    }
+
+    return $value;
+}
+
+add_filter( 'get_post_metadata', 'today_filter_thumbnail_ids', 20, 4 );
+
+
+/**
+ * Filters requests for WordPress's built-in author name retrieval functions.
+ *
+ * Useful for feeds and third-party plugins that reference basic post
+ * author information.
+ */
+function today_filter_post_author_name( $author_name ) {
+	if ( ! is_admin() ) {
+		global $post;
+		$author_byline = get_field( 'post_author_byline', $post );
+		if ( $author_byline ) {
+			$author_name = $author_byline;
+		}
+	}
+
+	return $author_name;
+}
+
+add_filter( 'the_author', 'today_filter_post_author_name', 10 );
+add_filter( 'the_author_display_name', 'today_filter_post_author_name', 10 );
+
+
+/**
  * Returns an attachment ID for the desired thumbnail
  * image of a given post.  Optionally returns a fallback
  * if no image is available.
@@ -44,35 +95,6 @@ function today_get_thumbnail_id( $post, $use_fallback=true ) {
 
 	return $attachment_id;
 }
-
-
-/**
- * Filters requests for WordPress's built-in `get_post_thumbnail_id()`
- * to return the Header Image/Thumbnail field for posts.
- *
- * Useful for third-party plugins that reference thumbnails.
- *
- * @since 1.0.0
- * @author Jo Dickson
- * @param mixed $value A determined thumbnail ID, or null
- * @param int $object_id Object ID (in this case, a post object ID)
- * @param string $meta_key The meta key name
- * @param bool $single Whether to return only the first value of the specified $meta_key
- * @return mixed The thumbnail ID, or null
- */
-function today_filter_thumbnail_ids( $value, $object_id, $meta_key, $single ) {
-    if ( $meta_key === '_thumbnail_id' ) {
-		$post = get_post( $object_id );
-		if ( $post instanceof WP_Post && $post->post_type === 'post' ) {
-			$attachment = get_field( 'post_header_image', $post );
-			$value      = isset( $attachment['id'] ) ? $attachment['id'] : null;
-		}
-    }
-
-    return $value;
-}
-
-add_filter( 'get_post_metadata', 'today_filter_thumbnail_ids', 20, 4 );
 
 
 /**


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added hooks that modify post author display names on the site frontend.  Functions for displaying single posts now use vanilla WP author-fetching functions when grabbing author names.  This update has the added benefit of making AMP layout author data consistent with the site frontend.
- Added hook that modifies a post's enclosure value, which is used in RSS/Atom fields to represent the post's thumbnail.  RSS feed thumbnails should now be accurate with what's displayed on the frontend.
- Fixed bug in `today_get_thumbnail_url` that would result in posts using a header video and custom thumbnail image displaying the wrong thumbnail

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps fix consistency issues between the site frontend and feed data.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
