### PR TITLE
Force default Resource Link Type term on Resource Links

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -299,3 +299,25 @@ function today_post_insert_override( $post_id, $post, $update ) {
 }
 
 add_action( 'wp_insert_post', 'today_post_insert_override', 10, 3 );
+
+
+/**
+ * Sets a Resource Link's default Resource Link Type
+ * when the post is published, if a unique Resource Link Type
+ * wasn't provided.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ */
+function today_default_resource_link_type( $post_id, $post, $update ) {
+	if ( $post->post_type !== 'ucf_resource_link' ) {
+		return;
+	}
+
+	$terms = wp_get_post_terms( $post_id, 'resource_link_types' );
+	if ( empty( $terms ) ) {
+		wp_set_object_terms( $post_id, 'external-story', 'resource_link_types' );
+	}
+}
+
+add_action( 'wp_insert_post', 'today_default_resource_link_type', 10, 3 );

--- a/includes/config.php
+++ b/includes/config.php
@@ -306,7 +306,7 @@ add_action( 'wp_insert_post', 'today_post_insert_override', 10, 3 );
  * when the post is published, if a unique Resource Link Type
  * wasn't provided.
  *
- * @since 1.0.0
+ * @since 1.0.2
  * @author Jo Dickson
  */
 function today_default_resource_link_type( $post_id, $post, $update ) {


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the Resource Link CPT is used for managing external stories on Today, having this default term set makes it easier for content editors and eliminates an extra step for them when creating new Resource Links.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
