### PR TITLE
Updated display logic not to show original date when it's empty

### DIFF
--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -101,7 +101,7 @@ function today_get_post_meta_info( $post ) {
 	$byline        = wptexturize( get_the_author() );
 	$updated_date  = date( $date_format, strtotime( $post->post_date ) );
 	$orig_date_val = get_field( 'post_header_publish_date', $post );
-	$original_date = isset( $orig_date_val ) ? date( $date_format, strtotime( $orig_date_val ) ) : $updated_date;
+	$original_date = ! empty( $orig_date_val ) ? date( $date_format, strtotime( $orig_date_val ) ) : $updated_date;
 
 	ob_start();
 ?>


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Ensures an empty `post_header_publish_date` is not displayed on the front end. Updating the `isset` check to `! empty` handles the empty string bug when the post is saved as a draft (before it's been published).

**Motivation and Context**
When working on stories, the writers were noticing an "Originally Published: Jan 1, 1970" in the heading. This was happening because the `post_header_publish_date` meta value is not set with a proper value until the post is published, but is saved as an empty string. An empty string passed into the PHP `Date` class will evaluate at 1/1/70. 

**How Has This Been Tested?**
The changes is available in dev and can be tested using the steps outlined in Issue #72.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
