### PR TITLE
Consistent excerpt values

### DIFF
--- a/includes/excerpts.php
+++ b/includes/excerpts.php
@@ -4,31 +4,27 @@
  */
 
 /**
- * Returns the post excerpt. Handles necessary postdata setup.
+ * Overrides the returned value for post excerpts retrieved using
+ * `get_the_excerpt()`.
  *
- * @since 1.0.0
+ * @since 1.0.7
  * @author Jo Dickson
- * @param object $post A WP_Post object
- * @param int $length Specify a custom length for the excerpt.
- * @return string Sanitized post excerpt
+ * @param string $excerpt The post excerpt
+ * @param object $post WP_Post object
+ * @return string Modified excerpt
  */
-function today_get_excerpt( $post, $length=TODAY_DEFAULT_EXCERPT_LENGTH ) {
-	if ( ! ( $post instanceof WP_Post ) ) return '';
-
-	$excerpt = '';
-
+function today_get_the_excerpt( $excerpt, $post ) {
 	if ( $deck = get_field( 'post_header_deck', $post ) ) {
-		$excerpt = wp_strip_all_tags( $deck );
+		$excerpt = $deck;
 	}
 	else if ( $resource_link_desc = get_field( 'ucf_resource_link_description', $post ) ) {
-		$excerpt = wp_strip_all_tags( $resource_link_desc );
-	}
-	else {
-		$excerpt = ucfwp_get_excerpt( $post, $length );
+		$excerpt = $resource_link_desc;
 	}
 
 	return $excerpt;
 }
+
+add_filter( 'get_the_excerpt', 'today_get_the_excerpt', 10, 2 );
 
 
 /**

--- a/includes/features.php
+++ b/includes/features.php
@@ -132,7 +132,7 @@ function today_display_feature_horizontal( $post, $args=array() ) {
 	$excerpt_length = ( $type === 'secondary' ) ? TODAY_SHORT_EXCERPT_LENGTH : TODAY_DEFAULT_EXCERPT_LENGTH;
 	// Explicitly overrwrite excerpt length if it's provided as an arg.
 	$excerpt_length = isset( $custom_excerpt_length ) ? $custom_excerpt_length : $excerpt_length;
-	$excerpt        = ( $use_excerpt ) ? today_get_excerpt( $post, $excerpt_length ) : '';
+	$excerpt        = ( $use_excerpt ) ? ucfwp_get_excerpt( $post, $excerpt_length ) : '';
 	$subhead        = ( $use_subhead ) ? today_get_feature_subhead( $post ) : '';
 	$thumbnail      = '';
 	$thumbnail_col_class = 'col-4 col-sm-3'; // classes for assumed default $type of 'secondary'
@@ -211,7 +211,7 @@ function today_display_feature_vertical( $post, $args=array() ) {
 	$excerpt_length = ( $type === 'secondary' ) ? TODAY_SHORT_EXCERPT_LENGTH : TODAY_DEFAULT_EXCERPT_LENGTH;
 	// Explicitly overrwrite excerpt length if it's provided as an arg.
 	$excerpt_length = isset( $custom_excerpt_length ) ? $custom_excerpt_length : $excerpt_length;
-	$excerpt        = ( $use_excerpt ) ? today_get_excerpt( $post, $excerpt_length ) : '';
+	$excerpt        = ( $use_excerpt ) ? ucfwp_get_excerpt( $post, $excerpt_length ) : '';
 	$subhead        = ( $use_subhead ) ? today_get_feature_subhead( $post ) : '';
 	$thumbnail_size = ( $type === 'primary' ) ? 'large' : 'medium_large';
 	$thumbnail      = today_get_feature_thumbnail( $post, $thumbnail_size );


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Moved post type-specific excerpt overrides into a new `get_the_excerpt` hook, which ensures that native WordPress features that utilize excerpts (such as REST APIs) will consistently display overridden values (e.g. decks for stories).

With this update, `today_get_excerpt()` no longer behaves differently than the UCF WordPress Theme's `ucfwp_get_excerpt()`, and its usage has been replaced in the theme.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requested by Laura to ensure main site stories displayed on ucf.edu use decks instead of auto-generated excerpts.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested + reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
