### PR TITLE
Replaced date function with current_time

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -293,8 +293,9 @@ function today_post_insert_override( $post_id, $post, $update ) {
 
 	// Get post meta
 	$publish_date = get_post_meta( $post_id, 'post_header_publish_date', true );
+
 	if ( ! $publish_date ) {
-		update_post_meta( $post_id, 'post_header_publish_date', date( 'Y-m-d' ) );
+		update_post_meta( $post_id, 'post_header_publish_date', current_time( 'Y-m-d', false ) );
 	}
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Ensures that the "Originally Published" date meta field is set using the site's configured timezone by replacing the `date` function with WordPress's built in `current_time` function. 

**Motivation and Context**
Resolves #93 by ensuring the timezone configured on the site is taken into account when creating the date string.

**How Has This Been Tested?**
Changes are available for review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
