### PR TITLE
Improved editability of secondary homepage stories

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -107,7 +107,7 @@
                     "5cac9fc2da26b": {
                         "key": "5cac9fc2da26b",
                         "name": "primary_row",
-                        "label": "Primary Story Row",
+                        "label": "Primary Story",
                         "display": "block",
                         "sub_fields": [
                             {
@@ -223,7 +223,7 @@
                     "5caca77046afc": {
                         "key": "5caca77046afc",
                         "name": "secondary_row",
-                        "label": "Secondary Stories Row",
+                        "label": "Secondary Stories",
                         "display": "block",
                         "sub_fields": [
                             {
@@ -241,7 +241,7 @@
                                 },
                                 "collapsed": "field_5caca86a46b00",
                                 "min": 1,
-                                "max": 4,
+                                "max": 0,
                                 "layout": "block",
                                 "button_label": "Add Story",
                                 "sub_fields": [
@@ -305,7 +305,7 @@
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
-                                    "width": "20",
+                                    "width": "15",
                                     "class": "",
                                     "id": ""
                                 },
@@ -324,7 +324,7 @@
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
-                                    "width": "20",
+                                    "width": "15",
                                     "class": "",
                                     "id": ""
                                 },
@@ -343,7 +343,7 @@
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
-                                    "width": "20",
+                                    "width": "15",
                                     "class": "",
                                     "id": ""
                                 },
@@ -352,6 +352,34 @@
                                 "ui": 0,
                                 "ui_on_text": "",
                                 "ui_off_text": ""
+                            },
+                            {
+                                "key": "field_60301395830a5",
+                                "label": "Posts per Row",
+                                "name": "posts_per_row",
+                                "type": "select",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "15",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "1": "1",
+                                    "2": "2",
+                                    "3": "3",
+                                    "4": "4",
+                                    "6": "6"
+                                },
+                                "default_value": 3,
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "ui": 0,
+                                "return_format": "value",
+                                "ajax": 0,
+                                "placeholder": ""
                             }
                         ],
                         "min": "",
@@ -360,7 +388,7 @@
                     "5caca9ae46b03": {
                         "key": "5caca9ae46b03",
                         "name": "condensed_row",
-                        "label": "Condensed Stories Row",
+                        "label": "Condensed Stories",
                         "display": "block",
                         "sub_fields": [
                             {
@@ -519,7 +547,7 @@
             "tags",
             "send-trackbacks"
         ],
-        "active": 1,
+        "active": true,
         "description": ""
     },
     {
@@ -578,7 +606,7 @@
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",
-        "active": 1,
+        "active": true,
         "description": ""
     },
     {
@@ -799,7 +827,7 @@
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",
-        "active": 1,
+        "active": true,
         "description": ""
     },
     {
@@ -1171,7 +1199,7 @@
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",
-        "active": 1,
+        "active": true,
         "description": ""
     },
     {
@@ -1213,7 +1241,7 @@
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",
-        "active": 1,
+        "active": true,
         "description": ""
     },
     {
@@ -1519,7 +1547,7 @@
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",
-        "active": 1,
+        "active": true,
         "description": ""
     }
 ]

--- a/includes/homepage-functions.php
+++ b/includes/homepage-functions.php
@@ -33,7 +33,7 @@ function today_get_homepage_latest( $primary=false ) {
 	<?php if ( $posts ): ?>
 		<div class="row">
 			<?php foreach ( $posts as $post ): ?>
-				<div class="col-lg-4 mb-4">
+				<div class="col-md-4 mb-4">
 					<?php echo today_display_feature_vertical( $post ); ?>
 				</div>
 			<?php endforeach; ?>
@@ -94,7 +94,7 @@ function today_get_homepage_curated( $post_id, $primary=false ) {
 						'show_image'    => get_sub_field( 'show_image' ),
 						'show_excerpt'  => get_sub_field( 'show_excerpt' ),
 						'show_subhead'  => get_sub_field( 'show_subhead' ),
-						'posts_per_row' => count( $posts )
+						'posts_per_row' => get_sub_field( 'posts_per_row' ) ?: 3
 					) );
 
 					$markup .= today_post_list_display_feature( null, $posts, $atts );

--- a/includes/post-list-functions.php
+++ b/includes/post-list-functions.php
@@ -125,7 +125,7 @@ add_filter( 'ucf_post_list_display_condensed_before', 'today_post_list_display_c
 function today_post_list_display_feature( $content, $posts, $atts ) {
 	if ( $posts && ! is_array( $posts ) ) { $posts = array( $posts ); }
 
-	$item_col = 'col-lg';
+	$item_col = 'col-md';
 	if ( $atts['posts_per_row'] > 0 && ( 12 % $atts['posts_per_row'] ) === 0 ) {
 		// Use specific column size class if posts_per_row equates
 		// to a valid grid size


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added the ability to specify the number of posts per row in a set of Secondary Stories on the homepage, instead of enforcing a max of 4 per set.  Doing this allows editors to assign all stories in a single set, making it easier to add, remove, and re-order existing stories in the set.  (Previously, you could not drag and drop stories between Secondary Stories rows)
- Adjusted Secondary story columns to start at the -md breakpoint instead of -lg for better visual hierarchy at those screen sizes.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of initial sprint to improve Today admin features.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
