### PR TITLE
Author fallback logic, again

### DIFF
--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -97,9 +97,11 @@ function today_get_post_header_media( $post ) {
  * @return string HTML markup for the metadata content
  */
 function today_get_post_meta_info( $post ) {
+	// Use custom author byline or Author term name, or fall back to original publisher
+	$author_data   = today_get_post_author_data( $post, true );
+	$byline        = $author_data['name'] ?? '';
+
 	$date_format   = 'F j, Y';
-	$author_data   = today_get_post_author_data( $post );
-	$byline        = $author_data['name'] ?? null;
 	$updated_date  = date( $date_format, strtotime( $post->post_date ) );
 	$orig_date_val = get_field( 'post_header_publish_date', $post );
 	$original_date = ! empty( $orig_date_val ) ? date( $date_format, strtotime( $orig_date_val ) ) : $updated_date;


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added an option to `today_get_post_author_data()` to return original publisher data as an absolute fallback.  Currently, we only set the author name when the function falls back to original publisher data.
- Additionally, `today_get_post_author_data()` will now always return an array with all expected keys (never an empty array).
- Updated `today_get_post_meta_info()` to utilize original publisher data (restoring behavior currently in master).

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make sure we're displaying the author data we want to display/to make it easier to consistently return author data across theme functions.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
