### PR TITLE
Pegasus homepage - (rough) first pass

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -903,6 +903,11 @@
                     "param": "page_type",
                     "operator": "!=",
                     "value": "front_page"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "!=",
+                    "value": "template-pegasus_home.php"
                 }
             ]
         ],
@@ -912,6 +917,693 @@
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
+        "key": "group_604905e80fbff",
+        "title": "Pegasus Homepage Content",
+        "fields": [
+            {
+                "key": "field_604905e816f87",
+                "label": "What type of content should be displayed on the Pegasus homepage?",
+                "name": "page_content_type",
+                "type": "radio",
+                "instructions": "",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "curated": "Curated content",
+                    "custom": "Custom markup"
+                },
+                "allow_null": 0,
+                "other_choice": 0,
+                "default_value": "curated",
+                "layout": "vertical",
+                "return_format": "value",
+                "save_other_choice": 0
+            },
+            {
+                "key": "field_604905e816fab",
+                "label": "Custom Page Content",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_604905e816f87",
+                            "operator": "==",
+                            "value": "custom"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_604a706de57a9",
+                "label": "Featured Stories",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_604905e816f87",
+                            "operator": "==",
+                            "value": "curated"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_604a7155e57ad",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Content block displayed at the top of the page.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_604905e816f9d",
+                "label": "Featured Stories",
+                "name": "primary_content",
+                "type": "clone",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_604905e816f87",
+                            "operator": "==",
+                            "value": "curated"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "clone": [
+                    "field_5cac9fb846af9"
+                ],
+                "display": "seamless",
+                "layout": "block",
+                "prefix_label": 0,
+                "prefix_name": 1
+            },
+            {
+                "key": "field_604924a5f3b33",
+                "label": "What's Trending",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_604905e816f87",
+                            "operator": "==",
+                            "value": "curated"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_604a7131e57ac",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Section for promoting trending social content.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_60493cc0f3b34",
+                "label": "Content",
+                "name": "trending_content",
+                "type": "wysiwyg",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "basic",
+                "media_upload": 0,
+                "delay": 1
+            },
+            {
+                "key": "field_604a70a8e57aa",
+                "label": "In This Issue",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_604905e816f87",
+                            "operator": "==",
+                            "value": "curated"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_604a7102e57ab",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Section that displays a link to the latest active issue and a list of stories in the issue.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_60493d35f3b35",
+                "label": "How should these stories be displayed?",
+                "name": "issue_content_type",
+                "type": "radio",
+                "instructions": "",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "latest": "Latest stories in the current active issue",
+                    "curated": "Curated story list"
+                },
+                "allow_null": 0,
+                "other_choice": 0,
+                "default_value": "latest",
+                "layout": "vertical",
+                "return_format": "value",
+                "save_other_choice": 0
+            },
+            {
+                "key": "field_604905e816fa5",
+                "label": "Curated Stories",
+                "name": "curated_stories",
+                "type": "flexible_content",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_60493d35f3b35",
+                            "operator": "==",
+                            "value": "curated"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layouts": {
+                    "5cac9fc2da26b": {
+                        "key": "5cac9fc2da26b",
+                        "name": "primary_row",
+                        "label": "Primary Story",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_604905e827c8d",
+                                "label": "Select a Story",
+                                "name": "post",
+                                "type": "post_object",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "post"
+                                ],
+                                "taxonomy": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "object",
+                                "ui": 1
+                            },
+                            {
+                                "key": "field_604905e827c97",
+                                "label": "Orientation",
+                                "name": "layout",
+                                "type": "select",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "40",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "horizontal": "Horizontal",
+                                    "vertical": "Vertical"
+                                },
+                                "default_value": "vertical",
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "ui": 0,
+                                "ajax": 0,
+                                "return_format": "value",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_604905e827c9f",
+                                "label": "Show Thumbnail",
+                                "name": "show_image",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "20",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "",
+                                "default_value": 1,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            },
+                            {
+                                "key": "field_604905e827ca7",
+                                "label": "Show Excerpt",
+                                "name": "show_excerpt",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "20",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "",
+                                "default_value": 1,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            },
+                            {
+                                "key": "field_604905e827cae",
+                                "label": "Show Subhead",
+                                "name": "show_subhead",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "20",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "5caca77046afc": {
+                        "key": "5caca77046afc",
+                        "name": "secondary_row",
+                        "label": "Secondary Stories",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_604905e827cb5",
+                                "label": "Select Stories",
+                                "name": "posts",
+                                "type": "repeater",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "collapsed": "field_5caca86a46b00",
+                                "min": 1,
+                                "max": 0,
+                                "layout": "block",
+                                "button_label": "Add Story",
+                                "sub_fields": [
+                                    {
+                                        "key": "field_604905e841734",
+                                        "label": "Story",
+                                        "name": "post",
+                                        "type": "post_object",
+                                        "instructions": "",
+                                        "required": 1,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "post_type": [
+                                            "post"
+                                        ],
+                                        "taxonomy": [],
+                                        "allow_null": 0,
+                                        "multiple": 0,
+                                        "return_format": "object",
+                                        "ui": 1
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "field_604905e827cbc",
+                                "label": "Orientation",
+                                "name": "layout",
+                                "type": "select",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "40",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "horizontal": "Horizontal",
+                                    "vertical": "Vertical"
+                                },
+                                "default_value": "vertical",
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "ui": 0,
+                                "ajax": 0,
+                                "return_format": "value",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_604905e827cc3",
+                                "label": "Show Thumbnails",
+                                "name": "show_thumbnail",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "15",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "",
+                                "default_value": 1,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            },
+                            {
+                                "key": "field_604905e827ccb",
+                                "label": "Show Excerpts",
+                                "name": "show_excerpt",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "15",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "",
+                                "default_value": 1,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            },
+                            {
+                                "key": "field_604905e827cd2",
+                                "label": "Show Subheads",
+                                "name": "show_subhead",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "15",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            },
+                            {
+                                "key": "field_604905e827cd9",
+                                "label": "Posts per Row",
+                                "name": "posts_per_row",
+                                "type": "select",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "15",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "1": "1",
+                                    "2": "2",
+                                    "3": "3",
+                                    "4": "4",
+                                    "6": "6"
+                                },
+                                "default_value": 3,
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "ui": 0,
+                                "return_format": "value",
+                                "ajax": 0,
+                                "placeholder": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "5caca9ae46b03": {
+                        "key": "5caca9ae46b03",
+                        "name": "condensed_row",
+                        "label": "Condensed Stories",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_604905e827ce1",
+                                "label": "Select Stories",
+                                "name": "posts",
+                                "type": "repeater",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "collapsed": "",
+                                "min": 1,
+                                "max": 0,
+                                "layout": "block",
+                                "button_label": "Add Story",
+                                "sub_fields": [
+                                    {
+                                        "key": "field_604905e863171",
+                                        "label": "Story",
+                                        "name": "post",
+                                        "type": "post_object",
+                                        "instructions": "",
+                                        "required": 1,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "post_type": [
+                                            "post"
+                                        ],
+                                        "taxonomy": [],
+                                        "allow_null": 0,
+                                        "multiple": 0,
+                                        "return_format": "object",
+                                        "ui": 1
+                                    }
+                                ]
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "5caca93746b01": {
+                        "key": "5caca93746b01",
+                        "name": "custom",
+                        "label": "Custom",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_604905e827ce8",
+                                "label": "Custom Content",
+                                "name": "custom_content",
+                                "type": "wysiwyg",
+                                "instructions": "Specify arbitrary, custom content to add to this row.",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 1,
+                                "delay": 0
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    }
+                },
+                "button_label": "Add Row",
+                "min": "",
+                "max": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "page"
+                },
+                {
+                    "param": "current_user_role",
+                    "operator": "==",
+                    "value": "administrator"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "template-pegasus_home.php"
+                }
+            ],
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "page"
+                },
+                {
+                    "param": "current_user_role",
+                    "operator": "==",
+                    "value": "super_admin"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "template-pegasus_home.php"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": [
+            "excerpt",
+            "page_attributes",
+            "featured_image",
+            "categories",
+            "tags",
+            "send-trackbacks"
+        ],
         "active": true,
         "description": ""
     },

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -925,55 +925,6 @@
         "title": "Pegasus Homepage Content",
         "fields": [
             {
-                "key": "field_604905e816f87",
-                "label": "What type of content should be displayed on the Pegasus homepage?",
-                "name": "page_content_type",
-                "type": "radio",
-                "instructions": "",
-                "required": 1,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "choices": {
-                    "curated": "Curated content",
-                    "custom": "Custom markup"
-                },
-                "allow_null": 0,
-                "other_choice": 0,
-                "default_value": "curated",
-                "layout": "vertical",
-                "return_format": "value",
-                "save_other_choice": 0
-            },
-            {
-                "key": "field_604905e816fab",
-                "label": "Custom Page Content",
-                "name": "",
-                "type": "message",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_604905e816f87",
-                            "operator": "==",
-                            "value": "custom"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "",
-                "new_lines": "wpautop",
-                "esc_html": 0
-            },
-            {
                 "key": "field_604a706de57a9",
                 "label": "Featured Stories",
                 "name": "",
@@ -1597,8 +1548,8 @@
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": [
+            "the_content",
             "excerpt",
-            "page_attributes",
             "featured_image",
             "categories",
             "tags",

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -995,6 +995,39 @@
                 "prefix_name": 1
             },
             {
+                "key": "field_604f8975b6ad2",
+                "label": "The Feed",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_604f8bd0b6ad8",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Section that contains a compact list of UCF Today stories.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
                 "key": "field_604924a5f3b33",
                 "label": "What's Trending",
                 "name": "",
@@ -1504,6 +1537,146 @@
                 "button_label": "Add Row",
                 "min": "",
                 "max": ""
+            },
+            {
+                "key": "field_604f8cb0eb43b",
+                "label": "Banner Ad",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_604f8ce5eb43c",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Optional block of content displayed immediately underneath the In This Issue section. Can be used for promotional items\/banner ads, or other arbitrary content.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_604f8d15eb43d",
+                "label": "Content",
+                "name": "banner_content",
+                "type": "wysiwyg",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "basic",
+                "media_upload": 0,
+                "delay": 1
+            },
+            {
+                "key": "field_604f898fb6ad3",
+                "label": "Events",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_604f8baab6ad7",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Block of content that contains a stylized list of events from the UCF Events system.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_604f8998b6ad4",
+                "label": "Featured Gallery",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_604f8b88b6ad6",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Section that displays a link to a featured gallery story.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_604f8a20b6ad5",
+                "label": "Featured Gallery",
+                "name": "featured_gallery",
+                "type": "post_object",
+                "instructions": "Choose a post that should be displayed in this section.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    "post"
+                ],
+                "taxonomy": "",
+                "allow_null": 0,
+                "multiple": 0,
+                "return_format": "object",
+                "ui": 1
             }
         ],
         "location": [

--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,7 @@ include_once TODAY_THEME_DIR . 'includes/header-functions.php';
 include_once TODAY_THEME_DIR . 'includes/sidebar-functions.php';
 include_once TODAY_THEME_DIR . 'includes/homepage-functions.php';
 include_once TODAY_THEME_DIR . 'includes/post-functions.php';
+include_once TODAY_THEME_DIR . 'includes/pegasus-functions.php';
 include_once TODAY_THEME_DIR . 'includes/archive-functions.php';
 include_once TODAY_THEME_DIR . 'includes/tag-cloud-functions.php';
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -256,13 +256,15 @@ add_filter( 'acf/fields/wysiwyg/toolbars', 'today_acf_inline_text_toolbar' );
  * @since 1.0.0
  * @author Jo Dickson
  */
-function today_acf_homepage_wysiwyg_position() {
+function today_acf_reposition_wysiwyg() {
 ?>
 <script type="text/javascript">
 	(function($) {
 		$(document).ready(function(){
-			// field_5cac9ecc97b7c = "Custom Page Content" Message field (placeholder)
-			$('.acf-field-5cac9ecc97b7c .acf-input').append( $('#postdivrich') );
+			// field_5cac9ecc97b7c = "Custom Page Content" Message field (placeholder) on Homepage Fields group
+			// field_604905e816fab = "Custom Page Content" Message field (placeholder) on Pegasus Homepage Fields group
+			$('.acf-field-5cac9ecc97b7c .acf-input, .acf-field-604905e816fab .acf-input')
+				.append( $('#postdivrich') );
 		});
 	})(jQuery);
 </script>
@@ -275,7 +277,7 @@ function today_acf_homepage_wysiwyg_position() {
 <?php
 }
 
-add_action( 'acf/input/admin_head', 'today_acf_homepage_wysiwyg_position' );
+add_action( 'acf/input/admin_head', 'today_acf_reposition_wysiwyg' );
 
 
 /**

--- a/includes/config.php
+++ b/includes/config.php
@@ -262,8 +262,7 @@ function today_acf_reposition_wysiwyg() {
 	(function($) {
 		$(document).ready(function(){
 			// field_5cac9ecc97b7c = "Custom Page Content" Message field (placeholder) on Homepage Fields group
-			// field_604905e816fab = "Custom Page Content" Message field (placeholder) on Pegasus Homepage Fields group
-			$('.acf-field-5cac9ecc97b7c .acf-input, .acf-field-604905e816fab .acf-input')
+			$('.acf-field-5cac9ecc97b7c .acf-input')
 				.append( $('#postdivrich') );
 		});
 	})(jQuery);

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -64,8 +64,17 @@ function today_get_header_content_type( $content_type, $obj ) {
 
 		if ( in_array( $post_type, array( 'post', 'ucf_statement' ) ) ) {
 			$content_type = 'post';
-		} elseif ( $post_type === 'page' &&	$post_template === 'template-category.php' ) {
-			$content_type = 'category';
+		} elseif ( $post_type === 'page' ) {
+			switch ( $post_template ) {
+				case 'template-category.php':
+					$content_type = 'category';
+					break;
+				case 'template-pegasus_home.php':
+					$content_type = 'pegasus_home';
+					break;
+				default:
+					break;
+			}
 		}
 	}
 

--- a/includes/homepage-functions.php
+++ b/includes/homepage-functions.php
@@ -166,9 +166,7 @@ function today_get_homepage_content( $post_id, $primary=false ) {
 		case 'custom':
 		default:
 			if ( $primary ) return '';
-			ob_start();
-			the_content();
-			$content = ob_get_clean();
+			$content = get_the_content( null, false, $post_id );
 			break;
 	}
 

--- a/includes/pegasus-functions.php
+++ b/includes/pegasus-functions.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Functions related to Pegasus stories and their
+ * display on the frontend
+ */
+
+
+/**
+ * TODO
+ */
+function today_get_pegasus_current_issue() {
+	return true;
+}
+
+
+/**
+ * Returns featured posts markup for the Pegasus homepage.
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @param int $post_id ID of the Pegasus homepage post
+ * @return string HTML markup
+ */
+function today_get_pegasus_home_featured( $post_id ) {
+	return today_get_homepage_curated( $post_id, true );
+}
+
+
+/**
+ * TODO
+ */
+function today_get_pegasus_home_in_this_issue( $post_id ) {
+	$issue        = today_get_pegasus_current_issue();
+	$content_type = get_field( 'issue_content_type', $post_id );
+	$content      = '<div class="row">';
+
+	if ( $issue ) {
+		ob_start();
+	?>
+		<div class="col-8 offset-2 col-sm-6 offset-sm-3 col-md-3 offset-md-0 mb-5 mb-md-0 pr-md-4 pr-lg-5 text-center">
+			<h2 class="h6 text-uppercase letter-spacing-2 mb-3">In This Issue</h2>
+			<a href="#TODO">
+				<img class="img-fluid" src="https://placehold.it/320x416/" alt="">
+				<strong class="text-uppercase letter-spacing-2 text-secondary d-block mt-3" style="font-size: .8em;">TODO Issue Name Here</strong>
+			</a>
+			<hr class="hr-primary hr-3 w-25" role="presentation">
+		</div>
+		<div class="col-md-9">
+	<?php
+		$content .= ob_get_clean();
+	} else {
+		$content .= '<div class="col">';
+	}
+
+	switch ( $content_type ) {
+		case 'curated':
+			$content .= today_get_homepage_curated( $post_id, false );
+			break;
+		case 'latest':
+		default:
+			$posts = get_posts( array(
+				// TODO filter by issue; remove numberposts
+				'numberposts' => 12
+			) );
+			ob_start();
+		?>
+			<?php if ( $posts ): ?>
+			<div class="row">
+				<?php foreach ( $posts as $post ): ?>
+					<div class="col-md-4 mb-4">
+						<?php echo today_display_feature_vertical( $post ); ?>
+					</div>
+				<?php endforeach; ?>
+			</div>
+			<?php else: ?>
+			<p>No results found.</p>
+			<?php endif; ?>
+		<?php
+			$content .= ob_get_clean();
+			break;
+	}
+
+	$content .= '</div></div>';
+
+	return $content;
+}

--- a/includes/pegasus-functions.php
+++ b/includes/pegasus-functions.php
@@ -6,7 +6,11 @@
 
 
 /**
- * TODO
+ * TODO Returns the latest active Pegasus issue.
+ *
+ * @since TODO
+ * @author TODO
+ * @return TODO
  */
 function today_get_pegasus_current_issue() {
 	return true;
@@ -27,7 +31,12 @@ function today_get_pegasus_home_featured( $post_id ) {
 
 
 /**
- * TODO
+ * TODO Returns markup for the "In This Issue" portion
+ * of the Pegasus homepage.
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @return string HTML markup
  */
 function today_get_pegasus_home_in_this_issue( $post_id ) {
 	$issue        = today_get_pegasus_current_issue();

--- a/template-parts/header_content-pegasus_home.php
+++ b/template-parts/header_content-pegasus_home.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Header content template for the 'Pegasus Home' page template
+ * TODO
+ */
+?>
+
+<?php
+global $post;
+
+$title = wptexturize( $post->post_title );
+?>
+
+<?php if ( $title ): ?>
+<div class="container d-flex flex-column text-center mt-4 mt-md-5">
+	<div class="row align-items-center">
+		<div class="col mb-4 mb-sm-0">
+			<a class="text-secondary font-weight-bold text-uppercase letter-spacing-2" style="font-size: .8em;" href="#TODO">
+				TODO latest issue
+			</a>
+		</div>
+		<div class="col-12 col-sm-8 flex-last flex-sm-unordered">
+			<!-- TODO svg logo instead of text here -->
+			<h1 class="display-3 font-weight-normal text-uppercase text-default mb-2">
+				<?php echo $title; ?>
+			</h1>
+			<a class="font-slab-serif text-uppercase text-secondary letter-spacing-2" href="#TODO">
+				TODO about blurb
+			</span>
+		</div>
+		<div class="col mb-4 mb-sm-0">
+			<a class="text-secondary font-weight-bold text-uppercase letter-spacing-2" style="font-size: .8em;" href="#TODO">
+				Archives
+			</a>
+		</div>
+	</div>
+	<div class="row flex-lg-first align-self-center align-self-lg-end mt-4 mb-2 mb-sm-4 mt-lg-0">
+		<div class="col d-flex flex-row align-items-center">
+			<strong class="small font-weight-bold letter-spacing-2 text-default text-uppercase mr-2">
+				Share
+			</strong>
+			<?php echo do_shortcode( '[ucf-social-icons size="sm"]' ); ?>
+		</div>
+	</div>
+
+	<div class="row hidden-xs-down">
+		<div class="col-12">
+			<hr role="presentation" class="mt-3 mt-lg-5 mb-0">
+			<hr role="presentation" class="hr-black hr-3 mt-1 mb-2">
+		</div>
+	</div>
+</div>
+<?php endif; ?>

--- a/template-parts/header_content-pegasus_home.php
+++ b/template-parts/header_content-pegasus_home.php
@@ -5,31 +5,27 @@
  */
 ?>
 
-<?php
-global $post;
-
-$title = wptexturize( $post->post_title );
-?>
-
-<?php if ( $title ): ?>
 <div class="container d-flex flex-column text-center mt-4 mt-md-5">
 	<div class="row align-items-center">
-		<div class="col mb-4 mb-sm-0">
+		<div class="col-12 col-sm-8 flex-last flex-sm-unordered">
+			<!-- TODO svg logo instead of hard-coded text here -->
+			<h1 class="display-3 font-weight-normal text-uppercase text-default mb-2">
+				Pegasus
+			</h1>
+			<a class="font-slab-serif text-uppercase text-secondary letter-spacing-2" href="#TODO">
+				<!-- TODO retrieve from Customizer option -->
+				TODO about blurb
+			</a>
+		</div>
+		<div class="col mb-4 mb-sm-0 flex-sm-first">
 			<a class="text-secondary font-weight-bold text-uppercase letter-spacing-2" style="font-size: .8em;" href="#TODO">
+				<!-- TODO retrieve latest issue, once issues are implemented -->
 				TODO latest issue
 			</a>
 		</div>
-		<div class="col-12 col-sm-8 flex-last flex-sm-unordered">
-			<!-- TODO svg logo instead of text here -->
-			<h1 class="display-3 font-weight-normal text-uppercase text-default mb-2">
-				<?php echo $title; ?>
-			</h1>
-			<a class="font-slab-serif text-uppercase text-secondary letter-spacing-2" href="#TODO">
-				TODO about blurb
-			</span>
-		</div>
 		<div class="col mb-4 mb-sm-0">
 			<a class="text-secondary font-weight-bold text-uppercase letter-spacing-2" style="font-size: .8em;" href="#TODO">
+				<!-- TODO retrieve from Customizer option -->
 				Archives
 			</a>
 		</div>
@@ -50,4 +46,3 @@ $title = wptexturize( $post->post_title );
 		</div>
 	</div>
 </div>
-<?php endif; ?>

--- a/template-pegasus_home.php
+++ b/template-pegasus_home.php
@@ -41,6 +41,12 @@
 
 <div class="jumbotron jumbotron-fluid bg-secondary py-4 mb-0">
 	<div class="container">
+		TODO banner content here
+	</div>
+</div>
+
+<div class="jumbotron jumbotron-fluid bg-secondary py-4 mb-0">
+	<div class="container">
 		<div class="row">
 			<div class="col-lg pt-lg-4 pr-lg-5 mb-5 mb-lg-0">
 				<!-- TODO configuration options -->

--- a/template-pegasus_home.php
+++ b/template-pegasus_home.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Template Name: Pegasus Homepage
+ * Template Post Type: page
+ */
+?>
+<?php get_header(); the_post(); ?>
+
+<div class="jumbotron jumbotron-fluid bg-secondary py-4 mb-0">
+	<div class="container">
+		<?php echo today_get_pegasus_home_featured( $post->ID, true ); ?>
+	</div>
+</div>
+
+<div class="jumbotron jumbotron-fluid bg-secondary py-4 mb-0">
+	<div class="container">
+		<div class="row">
+			<div class="col-md-6 col-lg-7 mb-5 mb-md-0 pt-md-4">
+				<h2 class="font-weight-black mb-4">The Feed</h2>
+				TODO
+			</div>
+			<div class="col">
+				<div class="card border-0 bg-faded h-100">
+					<div class="card-block p-4">
+						<h2 class="h6 heading-underline letter-spacing-2 mb-4">What's Trending</h2>
+						TODO
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="jumbotron jumbotron-fluid bg-secondary py-4 mb-0">
+	<div class="container">
+		<?php echo today_get_pegasus_home_in_this_issue( $post->ID ); ?>
+	</div>
+</div>
+
+<div class="jumbotron jumbotron-fluid bg-secondary py-4 mb-0">
+	<div class="container">
+		<div class="row">
+			<div class="col-lg pt-lg-4 pr-lg-5 mb-5 mb-lg-0">
+				<h2 class="font-weight-black">Events</h2>
+				<hr role="presentation">
+				<?php echo do_shortcode( '[ucf-events title="" layout="classic"]' ); ?>
+			</div>
+			<div class="col-lg">
+				<div class="card border-0 bg-faded mx-auto">
+					<div class="card-block p-4">
+						<a href="#TODO">
+							<h2 class="text-secondary">TODO Featured Gallery Name</h2>
+							<span class="badge badge-primary">TODO Category Name</span>
+							<img class="mt-3 img-fluid" src="https://placehold.it/767x600" alt="TODO">
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<?php get_footer(); ?>

--- a/template-pegasus_home.php
+++ b/template-pegasus_home.php
@@ -16,10 +16,12 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-6 col-lg-7 mb-5 mb-md-0 pt-md-4">
+				<!-- TODO configuration options? -->
 				<h2 class="font-weight-black mb-4">The Feed</h2>
 				TODO
 			</div>
 			<div class="col">
+				<!-- TODO pull content from ACF field -->
 				<div class="card border-0 bg-faded h-100">
 					<div class="card-block p-4">
 						<h2 class="h6 heading-underline letter-spacing-2 mb-4">What's Trending</h2>
@@ -41,11 +43,13 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-lg pt-lg-4 pr-lg-5 mb-5 mb-lg-0">
+				<!-- TODO configuration options -->
 				<h2 class="font-weight-black">Events</h2>
 				<hr role="presentation">
 				<?php echo do_shortcode( '[ucf-events title="" layout="classic"]' ); ?>
 			</div>
 			<div class="col-lg">
+				<!-- TODO configuration options -->
 				<div class="card border-0 bg-faded mx-auto">
 					<div class="card-block p-4">
 						<a href="#TODO">


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
An initial pass at setting up a new page template and ACF fields for defining Pegasus homepage content.  At this point, the following have been implemented:
- A new page template, `template-pegasus_home.php`, which is partially working/partially dummy content
- ACF fields, specifically for use with the `template-pegasus_home.php` template.  Right now, the featured stories and "in this issue" sections are the only functional sets of fields.
- A header_content template part specifically for the Pegasus homepage, `template-parts/header_content-pegasus_home.php`, with mostly temporary/dummy content

TODOs will be addressed in future PRs.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of initial sprint to begin implementing Pegasus articles in Today.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
