### PR TITLE
Fix for Related Stories

### DIFF
--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -672,6 +672,8 @@ function today_add_post_custom_fields() {
 			'taxonomy'          => 'post_tag',
 			'field_type'        => 'select',
 			'add_term'          => 0,
+			'allow_null'        => 1,
+			'return_format'     => 'object',
 		);
 
 		// Adds Source tab


### PR DESCRIPTION
**Description**
The stories that appeared in the Related Stories section were borked because the ACF field `post_primary_tag` wasn't set to return as an object and allow null values.

**Motivation and Context**
To fix it.

**How Has This Been Tested?**
Fix viewable in QA.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
