### PR TITLE
Removed aria label from navigation toggle button

### DIFF
--- a/template-parts/nav.php
+++ b/template-parts/nav.php
@@ -36,7 +36,7 @@ $menu          = wp_nav_menu( array(
 
 			<button class="navbar-toggler ml-auto align-self-start collapsed align-items-center" type="button" aria-controls="header-menu" aria-expanded="false">
 				<span class="navbar-toggler-text mr-1">Sections</span>
-				<span class="navbar-toggler-icon"></span>
+				<span class="navbar-toggler-icon" aria-hidden="true"></span>
 			</button>
 		</div>
 	</div>

--- a/template-parts/nav.php
+++ b/template-parts/nav.php
@@ -34,7 +34,7 @@ $menu          = wp_nav_menu( array(
 				<?php echo today_output_nav_weather_data(); ?>
 			<?php endif; ?>
 
-			<button class="navbar-toggler ml-auto align-self-start collapsed align-items-center" type="button" aria-controls="header-menu" aria-expanded="false" aria-label="Toggle navigation">
+			<button class="navbar-toggler ml-auto align-self-start collapsed align-items-center" type="button" aria-controls="header-menu" aria-expanded="false">
 				<span class="navbar-toggler-text mr-1">Sections</span>
 				<span class="navbar-toggler-icon"></span>
 			</button>


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Removes the `aria-label` attribute from the navigation toggle in the main menu.

**Motivation and Context**
It is not appropriate to have an `aria-label` and inner text that do not match. In this case, the `aria-label` was set to "Toggle navigation" while the button text read "Sections." Because the button has text, the `aria-label` is not necessary, and it was easier to just remove it.

**How Has This Been Tested?**
Changes are available in DEV for review.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.


Resolves #140 
